### PR TITLE
Fixed required_ruby_version in gemspec

### DIFF
--- a/mongoid-minitest.gemspec
+++ b/mongoid-minitest.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = Mongoid::MiniTest::VERSION
 
-  gem.required_ruby_version = '1.9.3'
+  gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'minitest', '~> 3.3.0'
   gem.add_dependency 'mongoid' , '~> 3.0.2'


### PR DESCRIPTION
Hi,

it's me again. I added the new version you released today to my Gemfile and ran the `bundle update` command. I was a little puzzled when Bundler told me this:

```
Installing mongoid-minitest (0.1.0) 
Gem::InstallError: mongoid-minitest requires Ruby version = 1.9.3.
An error occured while installing mongoid-minitest (0.1.0), and Bundler cannot continue.
Make sure that `gem install mongoid-minitest -v '0.1.0'` succeeds before bundling.
```

In fact I am using ruby 1.9.3-p194, so I took a look into the gemspec and found the line which causes the problem. Based on the [rubygems doc](http://docs.rubygems.org/read/chapter/20#required_ruby_version) I played around with the `required_ruby_version` and found out that this would do the trick:

``` ruby
gem.required_ruby_version = '>= 1.9.3'
```

Installing on 1.9.2 doesn't work now, but installing on 1.9.3 works. By the way: Why are you requiring 1.9.3? I ran the test suite on an ruby 1.9.2-p320 and nothing failed there. And as far as I saw neither mongoid nor minitest is requiring 1.9.3. :-)
