### PR TITLE
Allow non-array values for inclusion/exclusion matchers

### DIFF
--- a/lib/matchers/validations/exclusion.rb
+++ b/lib/matchers/validations/exclusion.rb
@@ -7,14 +7,14 @@ module Mongoid
         end
 
         def to_not_allow(*values)
-          @not_allowed_values = values.flatten
+          @not_allowed_values = (values.length > 1) ? values.flatten : values[0]
           self
         end
 
         def matches?(subject)
           return false unless result = super(subject)
 
-          if @not_allowed_values
+          if Array === @not_allowed_values
             allowed_values = @not_allowed_values - @validator.options[:in].to_a
             if allowed_values.empty?
               @positive_message << ' not allowing all values mentioned'
@@ -23,14 +23,23 @@ module Mongoid
               @negative_message << " #{to_sentence(allowed_values)}"
               result = false
             end
+          elsif @not_allowed_values
+            if @not_allowed_values == @validator.options[:in]
+              @positive_message << " not allowing values in #{@not_allowed_values.inspect}"
+            else
+              @negative_message << " not allowing values in #{@validator.options[:in].inspect}"
+              result = false
+            end
           end
 
           result
         end
 
         def description
-          if @not_allowed_values
+          if Array === @not_allowed_values
             super << " not allowing the values: #{to_sentence(@not_allowed_values)}"
+          elsif @not_allowed_values
+            super << " not allowing the values in #{@not_allowed_values.inspect}"
           end
         end
       end

--- a/lib/matchers/validations/inclusion.rb
+++ b/lib/matchers/validations/inclusion.rb
@@ -7,20 +7,27 @@ module Mongoid
         end
 
         def to_allow(*values)
-          @allowed_values = values.flatten
+          @allowed_values = (values.length > 1) ? values.flatten : values[0]
           self
         end
 
         def matches?(subject)
           return false unless result = super(subject)
 
-          if @allowed_values
+          if Array === @allowed_values
             not_allowed_values = @allowed_values - @validator.options[:in].to_a
             if not_allowed_values.empty?
               @positive_message << ' allowing all values mentioned'
             else
-              @negative_message << ' not allowing the following the  values:'
+              @negative_message << ' not allowing the following the values:'
               @negative_message << " #{not_allowed_values.inspect}"
+              result = false
+            end
+          elsif @allowed_values
+            if @allowed_values == @validator.options[:in]
+              @positive_message << " allowing values in #{@allowed_values.inspect}"
+            else
+              @negative_message << " allowing values in #{@validator.options[:in].inspect}"
               result = false
             end
           end
@@ -29,8 +36,10 @@ module Mongoid
         end
 
         def description
-          if @allowed_values
+          if Array === @allowed_values
             super << " allowing the values: #{to_sentence(@allowed_values)}"
+          elsif @allowed_values
+            super << " allowing the values in #{@allowed_values.inspect}"
           end
         end
       end

--- a/test/matchers/validations_test.rb
+++ b/test/matchers/validations_test.rb
@@ -24,6 +24,8 @@ describe 'Validations' do
 
     it { must validate_inclusion_of(:role).to_allow('user', 'admin') }
     it { must validate_exclusion_of(:email).to_not_allow('foo@bar.com', 'fizz@buzz.com') }
+    it { must validate_inclusion_of(:age).to_allow(0..200) }
+    it { must validate_exclusion_of(:age).to_not_allow(30..60) }
 
     it { must validate_confirmation_of(:password) }
     it { must validate_acceptance_of(:terms_of_use).accept_with('1') }

--- a/test/models/models.rb
+++ b/test/models/models.rb
@@ -37,6 +37,8 @@ class Person
 
   validates_inclusion_of :role, in: ['admin', 'user']
   validates_exclusion_of :email, in: ['foo@bar.com', 'fizz@buzz.com']
+  validates_inclusion_of :age, in: 0..200
+  validates_exclusion_of :age, in: 30..60
 end
 
 class Pet


### PR DESCRIPTION
Say you have this model that you wanted to test...

``` ruby
class Order
  include Mongoid::Document
  field :total, type: Integer
  validates_inclusion_of :total, in: 0...10000000
end
```

Currently you'd need to write...

``` ruby
describe Order do
  subject { Order }
  it { must validate_inclusion_of(:total).to_allow((0...10000000).to_a) }
end
```

This is _extremely_ slow.

This PR lets you do this instead:

``` ruby
describe Order do
  subject { Order }
  it { must validate_inclusion_of(:total).to_allow(0...10000000) }
end
```
