### PR TITLE
Minitest 5 compatibility?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.0
+
++ Upgrade to minitest 5
+  Pull Request [#20](https://github.com/frodsan/mongoid-minitest/pull/16) - *Ryan McGeary*.
+
++ Add support for Ruby 2.1 and 2.2 - *Ryan McGeary*.
+
 ## 1.0.0 - February 27, 2013
 
 + Extract Validation Matchers to [minitest-activemodel](https://github.com/frodsan/minitest-activemodel) gem.

--- a/mongoid-minitest.gemspec
+++ b/mongoid-minitest.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency 'minitest', '~> 4.1'
-  gem.add_dependency 'minitest-matchers', '~> 1.2'
+  gem.add_dependency 'minitest', '~> 5.0'
   gem.add_dependency 'mongoid' , '>= 3'
-  gem.add_dependency 'minitest-activemodel', '~> 1.0'
+  gem.add_dependency 'minitest-activemodel', '~> 1.1'
+
+  gem.add_development_dependency 'minitest-matchers'
   gem.add_development_dependency 'rake'
 end

--- a/mongoid-minitest.gemspec
+++ b/mongoid-minitest.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name          = 'mongoid-minitest'
-  gem.version       = '1.0.0'
+  gem.version       = '1.1.0'
 
   gem.authors       = ['Francesco Rodriguez', 'Sascha Wessel', 'Godfrey Chan', 'Ryan McGeary']
   gem.email         = ['lrodriguezsanc@gmail.com', 'godfreykfc@gmail.com', 'ryan@mcgeary.org']


### PR DESCRIPTION
Are there plans to make mongoid-minitest compatible with minitest 5? Activesupport 4.1+ now depends on minitest 5.1.