### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ Depend on either
 by adding one to your application's Gemfile.
 
 ```ruby
-gem 'mongoid-minitest', group: :test
+gem 'minitest-matchers', group: :test
 
 # - OR - #
 
-gem 'mongoid-minitest_vaccine', group: :test
+gem 'minitest-matchers_vaccine', group: :test
 ```
 
 And then execute:


### PR DESCRIPTION
Changed 'mongoid-minitest' to gem 'minitest-matchers' and 'mongoid-minitest_vaccine' to 'minitest-matchers_vaccine'.